### PR TITLE
feat: BOFA-18 Enable release-please and commit linting

### DIFF
--- a/.github/workflows/conventional-commit-lint-pr.yml
+++ b/.github/workflows/conventional-commit-lint-pr.yml
@@ -8,16 +8,12 @@ on:
         required: false
         type: boolean
         default: false
-      validate_single_commit:
-        required: false
-        type: boolean
-        default: true
 
 jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4.2.0 # funny number
+      - uses: amannn/action-semantic-pull-request@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -38,4 +34,3 @@ jobs:
             didn't match the configured pattern. Please ensure that the subject
             starts with a Jira issue key for the Big Creek (e.g. "BC-123")
             projet followed by a space, followed by a description.
-          validateSingleCommit: ${{ inputs.validate_single_commit }}

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,14 @@
+name: Lint Pull Request
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  lint-pr:
+    uses: PlaidypusDev/github-actions/.github/workflows/conventional-commit-lint-pr.yml@main
+    with:
+      jira_key: BOFA

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,15 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v3
+        with:
+          release-type: simple
+          package-name: github-actions

--- a/README.md
+++ b/README.md
@@ -4,10 +4,22 @@ This repository contains GitHub actions that can be reused across projects
 
 ## Workflows available:
 
+- [Conventional commit lint PR](#conventional-commit-lint-pr)
 - [Deploy to Cloud Run](#deploy-to-cloud-run)
 - [Remove old container images](#remove-old-containers-images)
-- [Conventional commit lint PR](#conventional-commit-lint-pr)
 - [Publish to container registry](#publish-to-container-registry)
+
+## Conventional commit lint PR
+
+[`conventional-commit-lint-pr.yml`](.github/workflows/conventional-commit-lint-pr.yml)
+
+This workflow lints PRs created with a conventional commit title. When using the "squash and merge" strategy, make sure to configure the repository to use the setting: [Default to PR title for squash merge commits](https://github.blog/changelog/2022-05-11-default-to-pr-titles-for-squash-merge-commit-messages/). For context, please read [this section](https://github.com/marketplace/actions/semantic-pull-request#legacy-configuration) of the `semantic-pull-request` action documentation.
+
+Inputs:
+| Name | Description | Required | Default |
+| ---- | ----------- | :------: | ------- |
+| jira_key | The JIRA key to check for when checking the ticket number. Example, `PLAN`. | ✅ | `N/A` |
+| require_scope | Require the conventional commit scope to be in the PR title | ❌ | `false` |
 
 ## Deploy to Cloud Run
 
@@ -50,17 +62,6 @@ Secrets:
 | ---- | ----------- | :------: |
 | GCP_SA_KEY | The JSON service account key | ✅ |
 
-## Conventional commit lint PR
-
-[`conventional-commit-lint-pr.yml`](.github/workflows/conventional-commit-lint-pr.yml)
-
-This workflow lints PRs created with a conventional commit title. When using the "squash and merge" strategy, make sure to configure the repository to use the setting: [Default to PR title for squash merge commits](https://github.blog/changelog/2022-05-11-default-to-pr-titles-for-squash-merge-commit-messages/). For context, please read [this section](https://github.com/marketplace/actions/semantic-pull-request#legacy-configuration) of the `semantic-pull-request` action documentation.
-
-Inputs:
-| Name | Description | Required | Default |
-| ---- | ----------- | :------: | ------- |
-| jira_key | The JIRA key to check for when checking the ticket number. Example, `PLAN`. | ✅ | `N/A` |
-| require_scope | Require the conventional commit scope to be in the PR title | ❌ | `false` |
 
 ## Publish to container registry
 

--- a/README.md
+++ b/README.md
@@ -50,15 +50,15 @@ Secrets:
 
 ## Conventional commit lint PR
 
-`.github/workflows/conventional-commit-lint-pr.yml`
-This workflow lints PRs created with a conventional commit title.
+[`conventional-commit-lint-pr.yml`](.github/workflows/conventional-commit-lint-pr.yml)
+
+This workflow lints PRs created with a conventional commit title. When using the "squash and merge" strategy, make sure to configure the repository to use the setting: [Default to PR title for squash merge commits](https://github.blog/changelog/2022-05-11-default-to-pr-titles-for-squash-merge-commit-messages/). For context, please read [this section](https://github.com/marketplace/actions/semantic-pull-request#legacy-configuration) of the `semantic-pull-request` action documentation.
 
 Inputs:
 | Name | Description | Required | Default |
 | ---- | ----------- | :------: | ------- |
 | jira_key | The JIRA key to check for when checking the ticket number. Example, `PLAN`. | ✅ | `N/A` |
 | require_scope | Require the conventional commit scope to be in the PR title | ❌ | `false` |
-| validate_single_commit | See [https://github.com/amannn/action-semantic-pull-request#configuration](https://github.com/amannn/action-semantic-pull-request#configuration) | ❌ | `true` |
 
 ## Publish to container registry
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This repository contains GitHub actions that can be reused across projects
 
 ## Deploy to Cloud Run
 
-`.github/workflows/deploy-to-cloud-run.yml` <br>
+[`deploy-to-cloud-run.yml`](.github/workflows/deploy-to-cloud-run.yml)
+
 This workflow will deploy a given container to Cloud Run and clean out the old images from the container registry after successfully deploying.
 
 ### Setting up the Google Cloud project
@@ -32,7 +33,8 @@ Secrets:
 
 ## Remove old containers images
 
-`.github/workflows/remove-old-images.yml`
+[`remove-old-images.yml`](.github/workflows/remove-old-images.yml)
+
 This workflow removes images from the Google Cloud container registry when they meet a specified age criteria.
 
 Inputs:
@@ -62,7 +64,8 @@ Inputs:
 
 ## Publish to container registry
 
-`.github/workflows/publish-to-container-registry.yml`
+[`publish-to-container-registry.yml`](.github/workflows/publish-to-container-registry.yml)
+
 This workflow publishes a Docker container to a Google Cloud container registry.
 
 Inputs:


### PR DESCRIPTION
This PR:
- Adds release-please to the repo
- Adds use of its own commit linting workflow
  - Removes a legacy option from the commit linting workflow
- Updates README