### PR TITLE
feat: BOFA-26 update remove-old-images workflow with tag-filter-any input

### DIFF
--- a/.github/workflows/remove-old-images.yml
+++ b/.github/workflows/remove-old-images.yml
@@ -7,6 +7,10 @@ on:
       gcp_project_id:
         required: true
         type: string
+      tag_filter_regex:
+        required: false
+        default: ".*"
+        type: string
       remove_images_keep:
         required: false
         default: "10"
@@ -38,4 +42,11 @@ jobs:
           echo "::set-output name=access_token::$access_token"
 
       - name: Remove old images
-        run: docker run -i us-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli --allow-tagged --keep ${{ inputs.remove_images_keep }} --repo gcr.io/${{ inputs.gcp_project_id }}/${{ inputs.repository_name }} --grace ${{ inputs.remove_images_grace }} --token ${{ steps.gcloud-access-token.outputs.access_token }}
+        uses: docker://us-docker.pkg.dev/gcr-cleaner/gcr-cleaner/gcr-cleaner-cli
+        with:
+          args: >-
+            -repo=gcr.io/${{ inputs.gcp_project_id }}/${{ inputs.repository_name }}
+            -token=${{ steps.gcloud-access-token.outputs.access_token }}
+            -tag-filter-any=${{ inputs.tag_filter_regex }}
+            -keep=${{ inputs.remove_images_keep }}
+            -grace=${{ inputs.remove_images_grace }}

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Secrets:
 | ---- | ----------- | :------: |
 | GCP_SA_KEY | The JSON service account key | ✅ |
 
-## Remove old containers images
+## Remove old container  images
 
 [`remove-old-images.yml`](.github/workflows/remove-old-images.yml)
 
@@ -54,6 +54,7 @@ Inputs:
 | ---- | ----------- | :------: | ------- |
 | gcp_project_id | The project ID for the Google Cloud project containing the Cloud Run instance | ✅ | `N/A` |
 | image_repo | The name of the image repository to remove images from | ✅ | `N/A` |
+| tag_filter_regex | Only images with at least one tag that matches this given regular expression will be deleted | ❌ | `".*"` |
 | remove_images_keep | How many images should be in the repository at a time | ❌ | `"10"` |
 | remove_images_grace | Don't remove containers that are younger than this time. The format is `<hours>h` | ❌ | `"336h"` |
 


### PR DESCRIPTION
This PR fixes the `remove-old-images` workflow, adding a new optional input for specifying a tag filter expression for images to be removed.